### PR TITLE
Make X-Trace report server work out of the box

### DIFF
--- a/src/java/INSTALL.txt
+++ b/src/java/INSTALL.txt
@@ -1,48 +1,48 @@
-X-Trace Java Distribution 2.0
+X-Trace Java Distribution 2.1
+=============================
 
-Installation
+X-Trace is a self-contained package; it doesn't need root or admininstrator
+privileges and doesn't require installation into a system directory. If you
+want to make it more easily accessible or make the proxy run as a service, take
+a look at the scripts in bin. The distribution doesn't do this at this point.
 
-X-Trace is a self-contained package, it doesn't need root or admininstrator
-priviledges and doesn't require installing into a system directory. If you want
-to make it more easily accessible, or make the proxy run as a service, take a
-look at the scripts in bin. The distribution doesn't do this at this point.
+From GitHub
+-----------
 
-1. From svn
+If you downloaded X-Trace from GitHub, you can build it from the source using
+Maven. Let <xtrace> be the directory of the repository.
 
-If you downloaded X-Trace from the svn repository, you can build it from the
-source using ant.  Let <xtrace> be the trunk directory of the repository.
+$ cd <xtrace>/src/java
+$ mvn package
 
-> cd <xtrace>/src/java
-> ant
+The JAR will be generated in <xtrace>/java/src/target. Yyou can now run the
+X-Trace backend (check that you have all necessary dependencies, see
+Dependencies below).
 
-The distribution is now in <xtrace>/java/src/build/dist, you can now enter that
-directory and run the X-Trace backend (check that you have all necessary 
-dependencies, see Dependencies below).
+$ cd <xtrace>/src/java
+$ bin/backend.sh
 
-> cd build/dist
-> bin/backend.sh
+You can also build the documentation with:
 
-You can also build the documentation by doing
+$ mvn site
 
-> ant javadoc
+The documentation will be in <xtrace>/src/java/target/site.
 
-The javadoc will be in <xtrace>/java/build/dist/docs/api
+From the release file
+---------------------
 
-2. From the release file
-
-If you obtained a release file, x-trace-2.0-<date>.tar.gz or .zip, extract it in
+If you obtained a release file, x-trace-2.0-<date>.tar.gz or .zip, extract it
 to your directory of choice (which we'll call <xtrace> for our example below).
-Run the backend with the following.
+Run the backend with the following:
 
-> bin/backend.sh
+$ bin/backend.sh
 
-After the backend is running you should be able to visit http://localhost:8080
-with your web browser to see the web portal to the X-Trace backend.
+Once the backend is running, the X-Trace reporting interface can be accessed by
+visiting http://localhost:8080.
 
 Dependencies
+------------
 
-All of the dependencies to run X-Trace are included in the distribution.
-For visualizing the results you will need a recent version of Graphviz.
-You will also need to have Java 1.5, ant, Ruby, and Perl.
-
-
+All of the dependencies to run X-Trace are included in the distribution. For
+visualizing the results you will need a recent version of Graphviz. You will
+also need to have Java 1.5, Maven, Ruby, and Perl.

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -53,4 +53,13 @@
 			</plugin>
 		</plugins>
 	</build>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.7</version>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/src/java/src/main/java/edu/berkeley/xtrace/server/XTraceServer.java
+++ b/src/java/src/main/java/edu/berkeley/xtrace/server/XTraceServer.java
@@ -78,7 +78,7 @@ public final class XTraceServer {
 	private static final Logger LOG = Logger.getLogger(XTraceServer.class);
 
 	private static ReportSource[] sources;
-	
+
 	private static BlockingQueue<String> incomingReportQueue, reportsToStorageQueue;
 
 	private static ThreadPerTaskExecutor sourcesExecutor;
@@ -86,17 +86,17 @@ public final class XTraceServer {
 	private static ExecutorService storeExecutor;
 
 	private static QueryableReportStore reportstore;
-	
+
 	private static final DateFormat JSON_DATE_FORMAT =
-		new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"); 
+		new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 	private static final DateFormat HTML_DATE_FORMAT =
-		new SimpleDateFormat("MMM dd yyyy, HH:mm:ss"); 
-	
+		new SimpleDateFormat("MMM dd yyyy, HH:mm:ss");
+
 	// Default number of results to show per page for web UI
 	private static final int PAGE_LENGTH = 25;
-	
+
 	public static void main(String[] args) {
-		
+
 		// If they use the default configuration (the FileTree report store),
 		// then they have to specify the directory in which to store reports
 		if (System.getProperty("xtrace.server.store") == null) {
@@ -106,7 +106,7 @@ public final class XTraceServer {
 			}
 			System.setProperty("xtrace.server.storedirectory", args[0]);
 		}
-		
+
 		setupReportSources();
 		setupReportStore();
 		setupBackplane();
@@ -114,22 +114,21 @@ public final class XTraceServer {
 	}
 
 	private static void setupReportSources() {
-		
+
 		incomingReportQueue = new ArrayBlockingQueue<String>(1024, true);
 		sourcesExecutor = new ThreadPerTaskExecutor();
-		
+
 		// Default input sources
 		String sourcesStr = "edu.berkeley.xtrace.server.UdpReportSource," +
-		                    "edu.berkeley.xtrace.server.TcpReportSource," +
-		                    "edu.berkeley.xtrace.server.ThriftReportSource";
-		
+		                    "edu.berkeley.xtrace.server.TcpReportSource";
+
 		if (System.getProperty("xtrace.server.sources") != null) {
 			sourcesStr = System.getProperty("xtrace.server.sources");
 		} else {
 			LOG.warn("No server report sources specified... using defaults (Udp,Tcp,Thrift)");
 		}
 		String[] sourcesLst = sourcesStr.split(",");
-		
+
 		sources = new ReportSource[sourcesLst.length];
 		for (int i = 0; i < sourcesLst.length; i++) {
 			try {
@@ -156,17 +155,17 @@ public final class XTraceServer {
 			sourcesExecutor.execute((Runnable) sources[i]);
 		}
 	}
-	
+
 	private static void setupReportStore() {
 		reportsToStorageQueue = new ArrayBlockingQueue<String>(1024);
-		
+
 		String storeStr = "edu.berkeley.xtrace.server.FileTreeReportStore";
 		if (System.getProperty("xtrace.server.store") != null) {
 			storeStr = System.getProperty("xtrace.server.store");
 		} else {
 			LOG.warn("No server report store specified... using default (FileTreeReportStore)");
 		}
-		
+
 		reportstore = null;
 		try {
 			reportstore = (QueryableReportStore) Class.forName(storeStr).newInstance();
@@ -180,7 +179,7 @@ public final class XTraceServer {
 			LOG.fatal("Could not find report store class", e1);
 			System.exit(-1);
 		}
-		
+
 		reportstore.setReportQueue(reportsToStorageQueue);
 		try {
 			reportstore.initialize();
@@ -188,16 +187,16 @@ public final class XTraceServer {
 			LOG.fatal("Unable to start report store", e);
 			System.exit(-1);
 		}
-		
+
 		storeExecutor = Executors.newSingleThreadExecutor();
 		storeExecutor.execute(reportstore);
-		
+
 		/* Every N seconds we should sync the report store */
 		String syncIntervalStr = System.getProperty("xtrace.server.syncinterval", "5");
 		long syncInterval = Integer.parseInt(syncIntervalStr);
 		Timer timer= new Timer();
 		timer.schedule(new SyncTimer(reportstore), syncInterval*1000, syncInterval*1000);
-		
+
 		/* Add a shutdown hook to flush and close the report store */
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 		  public void run() {
@@ -205,12 +204,12 @@ public final class XTraceServer {
 		  }
 		});
 	}
-	
+
 	private static void setupBackplane() {
 		new Thread(new Runnable() {
 			public void run() {
 				LOG.info("Backplane waiting for packets");
-				
+
 				while (true) {
 					String msg = null;
 					try {
@@ -224,20 +223,20 @@ public final class XTraceServer {
 			}
 		}).start();
 	}
-	
+
 	private static class ThreadPerTaskExecutor implements Executor {
 	     public void execute(Runnable r) {
 	         new Thread(r).start();
 	     }
 	 }
-	
+
 	private static void setupWebInterface() {
 		String webDir = System.getProperty("xtrace.backend.webui.dir");
 		if (webDir == null) {
 			LOG.warn("No webui directory specified... using default (./src/webui)");
 			webDir = "./src/webui";
 		}
-    
+
     int httpPort =
       Integer.parseInt(System.getProperty("xtrace.backend.httpport", "8080"));
 
@@ -253,12 +252,12 @@ public final class XTraceServer {
 		} catch (Exception e) {
 			LOG.warn("Failed to initialize Velocity", e);
 		}
-		
+
 		// Create Jetty server
     Server server = new Server(httpPort);
     Context context = new Context(server, "/");
-    
-    // Create a CGI servlet for scripts in webui/cgi-bin 
+
+    // Create a CGI servlet for scripts in webui/cgi-bin
     ServletHolder cgiHolder = new ServletHolder(new CGI());
     cgiHolder.setInitParameter("cgibinResourceBase", webDir + "/cgi-bin");
     if (System.getenv("PATH") != null) {
@@ -281,7 +280,7 @@ public final class XTraceServer {
         new TitleServlet()), "/title/*");
     context.addServlet(new ServletHolder(
         new TitleLikeServlet()), "/titleLike/*");
-    
+
     // Add an IndexServlet as the default servlet. This servlet will serve
     // a human-readable (HTML) latest tasks page for "/" and serve static
     // content for any other URL. Being the default servlet, it will get
@@ -289,14 +288,14 @@ public final class XTraceServer {
     // have registered servlets above.
     context.setResourceBase(webDir + "/html");
     context.addServlet(new ServletHolder(new IndexServlet()), "/");
-    
+
     try {
       server.start();
     } catch (Exception e) {
       LOG.warn("Unable to start web interface", e);
     }
 	}
-	
+
 	private static class GetReportsServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
@@ -320,14 +319,14 @@ public final class XTraceServer {
       }
     }
   }
-	
+
 	private static class GetLatestTaskServlet extends HttpServlet {
 	  protected void doGet(HttpServletRequest request, HttpServletResponse response)
 	      throws ServletException, IOException {
       response.setContentType("text/plain");
       response.setStatus(HttpServletResponse.SC_OK);
       Writer out = response.getWriter();
-      
+
       List<TaskRecord> task = reportstore.getLatestTasks(0, 1);
       if (task.size() != 1) {
         LOG.warn("getLatestTasks(1) returned " + task.size() + " entries");
@@ -346,7 +345,7 @@ public final class XTraceServer {
       }
 	  }
 	}
-  
+
   private static class TagServlet extends HttpServlet {
 		protected void doGet(HttpServletRequest request,
 				HttpServletResponse response) throws ServletException, IOException {
@@ -360,7 +359,7 @@ public final class XTraceServer {
 			}
 		}
 	}
-  
+
   private static class TitleServlet extends HttpServlet {
 		protected void doGet(HttpServletRequest request,
 				HttpServletResponse response) throws ServletException, IOException {
@@ -374,7 +373,7 @@ public final class XTraceServer {
 			}
 		}
 	}
-	
+
   private static class TitleLikeServlet extends HttpServlet {
 		protected void doGet(HttpServletRequest request,
 				HttpServletResponse response) throws ServletException, IOException {
@@ -388,7 +387,7 @@ public final class XTraceServer {
 			}
 		}
 	}
-  
+
   private static class IndexServlet extends DefaultServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException {
@@ -473,7 +472,7 @@ public final class XTraceServer {
 		int offset = getIntParam(request, "offset", 0);
 		return Math.max(offset, 0); // Don't allow negative
 	}
-	
+
 	/**
 	 * Read an integer parameter from a HTTP request, or return a default value
 	 * if the parameter is not specified.
@@ -491,7 +490,7 @@ public final class XTraceServer {
       return defaultValue;
     }
 	}
-  
+
 	private static final class SyncTimer extends TimerTask {
 		private QueryableReportStore reportstore;
 

--- a/src/webui/templates/tasks-html.vm
+++ b/src/webui/templates/tasks-html.vm
@@ -1,15 +1,15 @@
 <html>
-<head><title>X-Trace Viewer - $title<title></head>
+<head><title>X-Trace Viewer - $title</title></head>
 <body>
 <form action="#" method="get" name="searchForm" onSubmit="doSearch(); return false;">
 <p>
 <script language="javascript"><!--
 function doSearch() {
-  document.location.href = 
+  document.location.href =
     "/" + document.searchForm.searchType.value + "/" + document.searchForm.query.value;
 }
 //--></script>
-<a href="/">Return Home</a> | 
+<a href="/">Return Home</a> |
 Search by
 <select name="searchType">
 <option selected value="titleLike">title</option>
@@ -59,7 +59,7 @@ Search by
 <input type="hidden" name="offset" value="$offset" />
 Results per page: <input type="text" name="length" value="$length" size="6" />
 <input type="submit" value="Change" />
-</P> 
+</p>
 </form>
 #if ($showStats)
   <hr />


### PR DESCRIPTION
The X-Trace server does not work out of the box because the Thrift report source class is not included in the distribution and because of an HTML typo. Until the Thrift report source is added to the distribution, I've removed it from the default list of report sources.

I've been documenting my experiences as I go and will contribute a few documentation patches soon.
